### PR TITLE
Bugfix: fix not-found errors to redirect to mainIndexPath

### DIFF
--- a/handlers/http.go
+++ b/handlers/http.go
@@ -153,7 +153,13 @@ func (h *httpHandlers) web(rw http.ResponseWriter, r *http.Request) error {
 	}
 
 	p = filepath.Join(h.webFilePath, p)
-	return serveFile(rw, r, p, filepath.Join(h.webFilePath, "index.html"))
+	mainIndexPath := filepath.Join(h.webFilePath, "index.html")
+	err := serveFile(rw, r, p, mainIndexPath)
+	if status.Code(err) == codes.NotFound {
+		http.ServeFile(rw, r, mainIndexPath)
+		return nil
+	}
+	return err
 }
 
 type toitdocFileServer struct {


### PR DESCRIPTION
Otherwise links directly to packages does not work:
https://pkg.toit.io/package/github.com%2Ftoitware%2Fbme280-driver@v1.0.0