### PR TITLE
Add workflow dispatch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
We just need to add a workflow dispatch, so we trigger them also in branches. As long as there isn't one in main, branches can't run them.