### PR TITLE
Bake in ssh keys for common Git servers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ ENV SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts
 RUN mkdir -p /etc/ssh
 RUN ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
 RUN ssh-keyscan gitlab.com >> /etc/ssh/ssh_known_hosts
-RUN ssh-keyscan sourceforge.net >> /etc/ssh/ssh_known_hosts
-RUN ssh-keyscan bitbucket.org >> /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan shell.sf.net >> /etc/ssh/ssh_known_hosts
 
 ENTRYPOINT ["/registry_container"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV TPKG_PATH=/web_tpkg
 # Bake in the keys of common git servers.
 # Use the ENV variable 'SSH_KNOWN_HOSTS' to replace this file with a custom one.
 ENV SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts
+RUN mkdir -p /etc/ssh
 RUN ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
 RUN ssh-keyscan gitlab.com >> /etc/ssh/ssh_known_hosts
 RUN ssh-keyscan sourceforge.net >> /etc/ssh/ssh_known_hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN \
   dpkg --add-architecture i386 && \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 zlib1g:i386 ca-certificates && \
+  apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 zlib1g:i386 ca-certificates ssh && \
   rm -rf /var/lib/apt/lists/* && \
   update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,12 @@ ENV SDK_PATH=/sdk
 ENV TOITDOCS_VIEWER_PATH=/web_toitdocs
 ENV TPKG_PATH=/web_tpkg
 
+# Bake in the keys of common git servers.
+# Use the ENV variable 'SSH_KNOWN_HOSTS' to replace this file with a custom one.
+ENV SSH_KNOWN_HOSTS=/etc/ssh/ssh_known_hosts
+RUN ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan gitlab.com >> /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan sourceforge.net >> /etc/ssh/ssh_known_hosts
+RUN ssh-keyscan bitbucket.org >> /etc/ssh/ssh_known_hosts
+
 ENTRYPOINT ["/registry_container"]


### PR DESCRIPTION
We need to populate the known-hosts file to avoid MITM attacks. Interactively, ssh would ask the user to verify a key, but in a docker container that's not possible. That's why we fill them beforehand.

If another server is needed, use the ENV variable 'SSH_KNOWN_HOSTS' or create a new docker image that inherits from this one.