### PR TITLE
It's 'toit doc' and not 'toit toitdoc'.

### DIFF
--- a/pkg/toitdoc/generator.go
+++ b/pkg/toitdoc/generator.go
@@ -27,7 +27,7 @@ func provideGenerator(cfg *config.Config, logger *zap.Logger) *generator {
 
 func (g *generator) generateDocs(ctx context.Context, projectPath string, desc *tpkg.Desc, outFile string) error {
 	cmd := exec.CommandContext(ctx, g.cfg.ToitPath(),
-		"toitdoc", "build",
+		"doc", "build",
 		"--package",
 		"--version", desc.Version,
 		"--exclude-sdk",


### PR DESCRIPTION
There is an alias, so the command worked, but we prefer "doc".